### PR TITLE
fix: handle corrupted local storage and reactive card

### DIFF
--- a/src/components/RecordCard.vue
+++ b/src/components/RecordCard.vue
@@ -48,10 +48,10 @@ const { record } = defineProps<{
 
 const emit = defineEmits(['click'])
 
-const displayDate = formatDateForDisplay(record.date)
+const displayDate = computed(() => formatDateForDisplay(record.date))
 
 /** 最多顯示 50 字 */
-const previewContent = record.content.slice(0, 50)
+const previewContent = computed(() => record.content.slice(0, 50))
 
 /** 最多顯示 5 個 tag */
 const displayTags = computed(() => record.tags.slice(0, 5))

--- a/src/services/LocalStorageService.ts
+++ b/src/services/LocalStorageService.ts
@@ -78,13 +78,23 @@ export class LocalStorageService {
 
   // --- 私有工具方法 ---
   private static getDrafts(): DraftStorage {
-    const raw = localStorage.getItem(DRAFT_KEY)
-    return raw ? JSON.parse(raw) : {}
+    return this.safeGetItem<DraftStorage>(DRAFT_KEY, {})
   }
 
   private static getSettings(): SettingsStorage {
-    const raw = localStorage.getItem(SETTINGS_KEY)
-    return raw ? JSON.parse(raw) : { lastUsedTags: [] }
+    return this.safeGetItem<SettingsStorage>(SETTINGS_KEY, { lastUsedTags: [] })
+  }
+
+  private static safeGetItem<T>(key: string, fallback: T): T {
+    const raw = localStorage.getItem(key)
+    if (!raw) return fallback
+
+    try {
+      return JSON.parse(raw) as T
+    } catch (error) {
+      console.error(`⚠️ localStorage 解析失敗: ${key}`, error)
+      return fallback
+    }
   }
 
   private static safeSetItem(key: string, value: any) {


### PR DESCRIPTION
## Summary
- guard localStorage JSON parsing with safeGetItem helper
- make RecordCard display update when its record prop changes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b8a734d8832f9e3a0d181333e797